### PR TITLE
RFC: implicit begin

### DIFF
--- a/src/Zepto/Primitives.hs
+++ b/src/Zepto/Primitives.hs
@@ -909,7 +909,7 @@ apply' conti@(Cont (Continuation _ _ _ _ _ cs)) (Func _ (LispFun fparams varargs
             then throwError $ NumArgs (num fparams) args
             else liftIO (extendEnv fclosure $ zip (fmap ((,) vnamespace) fparams) args)
                   >>= bindVarArgs varargs
-                  >>= evalBody fbody
+                  >>= evalBody [(List ((fromSimple $ Atom "begin") : fbody))]
     where
         remainingArgs = drop (length fparams) args
         num = toInteger . length


### PR DESCRIPTION
This PR adds an implicit `begin` statement in functions, making the actual `begin` statement virtual obsolete.

Old functions versus new functions:
```clojure
; old
(define (print-and-incr arg)
  (begin
     (write arg)
     (add1 arg)))

; new
(define (print-and-incr arg)
  (write arg)
  (add1 arg))
```

As seen in the example above, it reduces nesting and makes the whole thing a bit more readable (IMHO).

It also reduces the syntactic clutter in `let` and related macros.

```clojure
; old
(let ((arg 1))
  (begin
     (write arg)
     (add1 arg)))

; new
(let ((arg 1))
  (write arg)
  (add1 arg))
```

Comments/Thoughts?