### PR TITLE
Use Hashmap instead of Map

### DIFF
--- a/src/Zepto/Parser.hs
+++ b/src/Zepto/Parser.hs
@@ -12,7 +12,7 @@ import Data.Word (Word8)
 import Numeric
 import Text.ParserCombinators.Parsec hiding (spaces)
 import Text.Regex.PCRE.Heavy (compileM)
-import qualified Data.Map
+import qualified Data.HashMap as DM
 import qualified Data.ByteString.Char8 as C (pack)
 
 import Zepto.Types
@@ -311,7 +311,7 @@ parseHashMap = do vals <- many parseExprPair
                     Right m ->
                       case duplicate (map fst m) of
                         Just d  ->  fail $ "Duplicate key: " ++ show d
-                        Nothing -> return $ HashMap $ Data.Map.fromList m
+                        Nothing -> return $ HashMap $ DM.fromList m
                     Left x  -> fail $ "All values must be simple (offending clause: " ++ show x ++ ")"
     where construct :: [(Simple, LispVal)] -> [[LispVal]] -> Either LispVal [(Simple, LispVal)]
           construct acc [] = Right acc

--- a/src/Zepto/Primitives.hs
+++ b/src/Zepto/Primitives.hs
@@ -11,7 +11,7 @@ import Control.Monad.Except
 import System.Directory
 import System.IO
 import System.IO.Error (tryIOError)
-import qualified Data.Map
+import qualified Data.HashMap as DM
 import qualified Control.Exception as CE
 import qualified Data.ByteString as BS (hPut, cons, splitAt, append, tail, index)
 
@@ -475,15 +475,15 @@ eval env conti (List [ByteVector x, SimpleVal (Atom a)]) = do
         i <- getVar env a
         eval env conti (List [ByteVector x, i])
 eval _ _ (List [ByteVector _, x]) = throwError $ TypeMismatch "integer" x
-eval _ _ (List [HashMap x, SimpleVal i@(Atom (':' : _))]) = if Data.Map.member i x
-        then return $ x Data.Map.! i
+eval _ _ (List [HashMap x, SimpleVal i@(Atom (':' : _))]) = if DM.member i x
+        then return $ x DM.! i
         else return $ fromSimple $ Nil ""
 eval env conti (List [HashMap x, SimpleVal (Atom a)]) = do
         i <- getVar env a
         eval env conti (List [HashMap x, i])
 eval _ _ (List [HashMap x, SimpleVal i]) =
-        if Data.Map.member i x
-          then return $ x Data.Map.! i
+        if DM.member i x
+          then return $ x DM.! i
           else return $ fromSimple $ Nil ""
 eval env conti (List [HashMap x, form]) = do
         i <- eval env conti form
@@ -493,9 +493,9 @@ eval env conti (HashComprehension (keyexpr, valexpr) (SimpleVal (Atom key), Simp
         case hash of
           HashMap e -> do
             keys <- mapM (filterAndApply key keyexpr cond env conti . fromSimple)
-                     (Data.Map.keys e)
-            vals <- mapM (internalApply val valexpr env conti) (Data.Map.elems e)
-            return $ HashMap $ Data.Map.fromList $ buildTuples (map toSimple keys) vals []
+                     (DM.keys e)
+            vals <- mapM (internalApply val valexpr env conti) (DM.elems e)
+            return $ HashMap $ DM.fromList $ buildTuples (map toSimple keys) vals []
           _ -> throwError $ TypeMismatch "hash-map" hash
     where buildTuples :: [Simple] -> [LispVal] -> [(Simple, LispVal)] -> [(Simple, LispVal)]
           buildTuples [] [] l = l
@@ -508,9 +508,9 @@ eval env conti (HashComprehension (keyexpr, valexpr) (SimpleVal (Atom key), Simp
         case hash of
           HashMap e -> do
             keys <- mapM (filterAndApply key keyexpr cond env conti . fromSimple)
-                     (Data.Map.keys e)
-            vals <- mapM (internalApply val valexpr env conti) (Data.Map.elems e)
-            return $ HashMap $ Data.Map.fromList $ buildTuples (map toSimple keys) vals []
+                     (DM.keys e)
+            vals <- mapM (internalApply val valexpr env conti) (DM.elems e)
+            return $ HashMap $ DM.fromList $ buildTuples (map toSimple keys) vals []
           _ -> throwError $ TypeMismatch "hash-map" hash
     where buildTuples :: [Simple] -> [LispVal] -> [(Simple, LispVal)] -> [(Simple, LispVal)]
           buildTuples [] [] l = l

--- a/src/Zepto/Primitives/ConversionPrimitives.hs
+++ b/src/Zepto/Primitives/ConversionPrimitives.hs
@@ -6,7 +6,7 @@ import Data.ByteString.Lazy (toStrict, fromStrict)
 import Data.Char (ord, chr)
 import Data.Complex (realPart, imagPart)
 import Data.IORef (readIORef)
-import Data.Map (empty, foldrWithKey, insert)
+import Data.HashMap (empty, foldWithKey, insert)
 import qualified Data.ByteString.Lazy as BSL (concat)
 
 import Zepto.Types
@@ -23,7 +23,7 @@ env2HashMapDoc = "converts an environment to a hashmap.\n\
 env2HashMap :: LispVal -> IOThrowsError LispVal
 env2HashMap (Environ x) = do
         env <- liftIO $ allBindings x
-        hashmap <- liftIO $ foldrWithKey accum (evaluate empty) env
+        hashmap <- liftIO $ foldWithKey accum (evaluate empty) env
         return $ HashMap hashmap
     where accum k v acc = do
             nv <- readIORef v

--- a/src/Zepto/Primitives/HashPrimitives.hs
+++ b/src/Zepto/Primitives/HashPrimitives.hs
@@ -1,7 +1,7 @@
 module Zepto.Primitives.HashPrimitives where
 
 import Control.Monad.Except
-import Data.Map (keys, elems, member, delete, fromList, toList)
+import Data.HashMap (keys, elems, member, delete, fromList, toList)
 
 import Zepto.Types
 

--- a/src/Zepto/Primitives/LogMathPrimitives.hs
+++ b/src/Zepto/Primitives/LogMathPrimitives.hs
@@ -6,7 +6,7 @@ import Data.Char
 import Data.Complex
 import Data.Word (Word32)
 
-import qualified Data.Map as DM (toList)
+import qualified Data.HashMap as DM (toList)
 import qualified Data.Ratio as Ratio (numerator, denominator)
 import qualified Text.Regex.PCRE.Light.Base as R
 

--- a/src/Zepto/Types.hs
+++ b/src/Zepto/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass, DeriveGeneric #-}
 module Zepto.Types (LispNum(..),
                     Simple(..),
                     LispVal(..),
@@ -40,6 +41,7 @@ import Data.ByteString (ByteString, unpack)
 import Data.Complex
 import Data.Dynamic
 import Data.Fixed
+import Data.Hashable
 import Data.IORef
 import Data.List (foldl')
 import Data.Ratio
@@ -47,7 +49,8 @@ import Control.Monad
 import Control.Monad.Except
 import System.IO
 import Text.ParserCombinators.Parsec.Error
-import qualified Data.Map as M
+import qualified GHC.Generics
+import qualified Data.HashMap as M
 import qualified Data.Array as A
 import qualified Text.Regex.PCRE.Light.Base as R
 
@@ -300,6 +303,15 @@ data LispNum = NumI Integer
              | NumC (Complex Double)
              | NumR Rational
              | NumS Int
+    deriving (Hashable, GHC.Generics.Generic)
+
+instance Hashable a => Hashable (Complex a) where
+  hash d = hash (realPart d) + hash (imagPart d)
+  hashWithSalt x d = hashWithSalt x (realPart d) + hashWithSalt x (imagPart d)
+
+instance Hashable R.Regex where
+  hash (R.Regex _ r)= hash r
+  hashWithSalt x (R.Regex _ r)= hashWithSalt x r
 
 data Simple = Atom String
             | Number LispNum
@@ -309,7 +321,7 @@ data Simple = Atom String
             | Bool Bool
             | Nil String
             | SimpleList [Simple]
-    deriving (Eq, Ord)
+    deriving (Eq, Ord, Hashable, GHC.Generics.Generic)
 
 instance Show LispVal where show = showVal
 -- | a LispVal data type comprising all Lisp data types

--- a/zepto.cabal
+++ b/zepto.cabal
@@ -77,6 +77,8 @@ Executable           zepto
                      ghc,
                      ghc-prim,
                      ghc-paths,
+                     hashable,
+                     hashmap,
                      MissingH,
                      mtl >= 2.2.1,
                      network,


### PR DESCRIPTION
This PR implements an experimental migration from Haskell's `Map` (balanced binary tree) to a `HashMap` (Patricia tree) for hashmaps.

We should do some performance measurements to see how this a affects zepto's overall performance.